### PR TITLE
[FIX] The unauthenticated git protocol on port 9418 is no longer supported

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -5,7 +5,7 @@ set nocompatible
 " dein.vim をインストールしていない場合は自動インストール
 if !isdirectory(s:dein_repo_dir)
   echo "install dein.vim..."
-  execute '!git clone git://github.com/Shougo/dein.vim' s:dein_repo_dir
+  execute '!git clone https://github.com/Shougo/dein.vim' s:dein_repo_dir
 endif
 execute 'set runtimepath^=' . s:dein_repo_dir
 


### PR DESCRIPTION
deinのインストールがこけていたため直した

```
lowbridgee@DESKTOP-54BV3IB:~$ vim
install dein.vim...
:!git clone git://github.com/Shougo/dein.vim /home/lowbridgee/dotfiles/dein/repos/github.com/Shougo/dein.vim
                                                                                                            Cloning into '/home/lowbridgee/dotfiles/dein/repos/github.com/Shougo/dein.vim'...
fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.

shell returned 128

Press ENTER or type command to continue

lowbridgee@DESKTOP-54BV3IB:~$
```

https://github.blog/2021-09-01-improving-git-protocol-security-github/